### PR TITLE
Improve moves-per-piece for center pieces

### DIFF
--- a/RCube/Cube.cpp
+++ b/RCube/Cube.cpp
@@ -406,16 +406,16 @@ void Cube::PushCenterPieces(byte src, byte dst, byte color)
 
 	if (IsOpposite(src, dst)) d = 2;
 
-	uint* mstack = new uint[Mid];		//Temporary array to keep track of columns that are being moved 
+	uint* mstack = new uint[R1];		//Temporary array to keep track of columns that are being moved
 
 	uint stkptr = 0;
 	uint pieces = 0;
-	uint start = Mid;
+	uint start = 1;
 
 	//If starting from a save state then set the start point
 	if (Itteration > 0) start = Itteration;
 
-	for (int quadrant = QState; quadrant < 4; ++quadrant)
+	for (int quadrant = QState; quadrant < 2; ++quadrant)
 	{
 		this->QState = quadrant;
 
@@ -436,8 +436,11 @@ void Cube::PushCenterPieces(byte src, byte dst, byte color)
 			{
 				pieces = 0;
 				stkptr = 0;
-				for (uint c = 1; c < Mid; ++c)
+				for (uint c = 1; c < R1; ++c)
 				{
+					//Avoid diagonal piece collisions
+					if (c == r) continue;
+
 					if (faces[src].GetRCQ(r, c, sq) == color)
 					{
 						pieces++;
@@ -476,7 +479,7 @@ void Cube::PushCenterPieces(byte src, byte dst, byte color)
 		}
 
 		//reset the start point
-		start = Mid;
+		start = 1;
 
 		//Rotate the src face to prepare for the next quadrant
 		Move(src, 0, 1);


### PR DESCRIPTION
Namely, traverse the whole center at once rather than just quadrants:

- the first quadrant pass covers everything except the c==r diagonal;
- the second pass is only for that diagonal, after rotation;
- everything is done by the end of the 2nd pass

The result is nearly double the pieces moved in each push-center-piece
commutator (for the first pass).

Additionally, only the remaining single pieces from the c==r diagonal
for each row are involved in the second pass, which means there will
be at most a single piece per row, which means no partial pushes for
any rows in the second pass.

(Note that the diagonals are excluded since these are the only pieces
that prevent pushing an entire row at once.)

Though the gains are not huge, the result is consistently fewer total
moves, and frequently less total time also.

A couple examples with seed 12345; size 400 and 401 (for even and odd
examples)

Before:

  Cube Size : 400
  Total Tiles : 960000
  Total Pieces : 955208
  Total Moves : 1374390
  Moves per piece : 1.438838
  Total Seconds : 2.6124629
  Cube is solved!

After:

  Cube Size : 400
  Total Tiles : 960000
  Total Pieces : 955208
  Total Moves : 1278179
  Moves per piece : 1.338116
  Total Seconds : 2.2853600
  Cube is solved!

---

Before:

  Cube Size : 401
  Total Tiles : 964806
  Total Pieces : 960002
  Total Moves : 1382691
  Moves per piece : 1.440300
  Total Seconds : 2.6162432
  Cube is solved!

After:

  Cube Size : 401
  Total Tiles : 964806
  Total Pieces : 960002
  Total Moves : 1284914
  Moves per piece : 1.338449
  Total Seconds : 2.2957793
  Cube is solved!