### PR TITLE
Add CMake support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ x86/
 [Aa][Rr][Mm]/
 [Aa][Rr][Mm]64/
 bld/
+build/
 [Bb]in/
 [Oo]bj/
 [Ll]og/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.16)
+project(RCube VERSION 0.1 LANGUAGES CXX)
+add_subdirectory(RCube)

--- a/RCube/CMakeLists.txt
+++ b/RCube/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_executable(RCube
+    Cube.cpp
+    Cube.h
+    CubeViewer.cpp
+    CubeViewer.h
+    Face.cpp
+    Face.h
+    Source.cpp
+    TinyPngOut.cpp
+    TinyPngOut.hpp
+)

--- a/README.md
+++ b/README.md
@@ -74,3 +74,12 @@ This algorithm is optimized for very large cubes. However it is terrible for sma
 
 ![](RCube/Images/MovesPerPiece.PNG)
 
+## Build and Run
+- Install CMake or an IDE with CMake support
+- Clone this repository and open directory in a terminal
+```sh
+cmake -B build -S .
+cd build
+cmake --build .
+RCube/RCube
+```


### PR DESCRIPTION
- Add `CMakeLists.txt` files required to build the RCube executable from source.
- Update README.md with the instructions to build and run RCube locally.